### PR TITLE
BUG: Solved "TypeError: Cannot read property 'length' of undefined" e…

### DIFF
--- a/resources/components/ionRangeSlider/ionRangeSliderComponent.js
+++ b/resources/components/ionRangeSlider/ionRangeSliderComponent.js
@@ -42,13 +42,13 @@ var IonRangeSliderComponent = BaseComponent.extend({
             query.fetchData(myself.parameters, function(values) {
 
                 sliderData = values;
+            
+                if(sliderData.resultset.length>0 && sliderData.resultset[0].length>0){ this.fromRange = sliderData.resultset[0][0]; }
+                if(sliderData.resultset.length>0 && sliderData.resultset[0].length>1){ this.toRange = sliderData.resultset[0][1]; }
+                if(sliderData.resultset.length>0 && sliderData.resultset[0].length>2){ this.minRange = sliderData.resultset[0][2]; }
+                if(sliderData.resultset.length>0 && sliderData.resultset[0].length>3){ this.maxRange = sliderData.resultset[0][3]; }
                 
             });
-
-            if(sliderData.resultset.length>0 && sliderData.resultset[0].length>0){ this.fromRange = sliderData.resultset[0][0]; }
-            if(sliderData.resultset.length>0 && sliderData.resultset[0].length>1){ this.toRange = sliderData.resultset[0][1]; }
-            if(sliderData.resultset.length>0 && sliderData.resultset[0].length>2){ this.minRange = sliderData.resultset[0][2]; }
-            if(sliderData.resultset.length>0 && sliderData.resultset[0].length>3){ this.maxRange = sliderData.resultset[0][3]; }
 
         }
 

--- a/resources/components/ionRangeSlider/ionRangeSliderComponent.js
+++ b/resources/components/ionRangeSlider/ionRangeSliderComponent.js
@@ -35,7 +35,6 @@ var IonRangeSliderComponent = BaseComponent.extend({
         if(myself.queryDefinition && Dashboards.objectToPropertiesArray(this.queryDefinition).length > 0){
 
             // create a query object
-            // var query = new Query(myself.queryDefinition);
             this.queryState = Dashboards.getQuery(myself.queryDefinition);
 
             /* The non-paging query handler only needs to concern itself
@@ -45,11 +44,6 @@ var IonRangeSliderComponent = BaseComponent.extend({
                 this.rawData = data;
                 this.processResponse(data);    
             },this);
-            // var handler = this.getSuccessHandler(success);
-
-            // fire the query objects fetchdata method
-            // no params and no callback
-            // query.fetchData(myself.parameters, handler);
             
             this.queryState.setAjaxOptions({async:true});
             this.queryState.fetchData(myself.parameters, success);


### PR DESCRIPTION
Solves "TypeError: Cannot read property 'length' of undefined" error when using slider connected to datasource in CDE dashboard. The cause of the problem is that sliderData.resultset.length is executed before sliderData = values, resulting in the slider failing to render on start of the dashboard.

Complete error:

```
CDF: Error updating render_SliderYear:Dashboards.log @ Dashboards.Main.js?v=8e89e10f9ca55858977d99c20148f7a6:82
    (anonymous function) @ Dashboards.Main.js?v=8e89e10f9ca55858977d99c20148f7a6:403
    setTimeout (async)Dashboards.updateLifecycle @ Dashboards.Main.js?v=8e89e10f9ca55858977d99c20148f7a6:415
    Dashboards.updateComponent @ Dashboards.Main.js?v=8e89e10f9ca55858977d99c20148f7a6:459Dashboards.updateAll @ Dashboards.Main.js?v=8e89e10f9ca55858977d99c20148f7a6:1127
    Dashboards.initEngine @ Dashboards.Main.js?v=8e89e10f9ca55858977d99c20148f7a6:880(anonymous function) @ Dashboards.Main.js?v=8e89e10f9ca55858977d99c20148f7a6:690
    fire @ jquery.js?v=08c235d357750c657ac1db7d1cf656a9:1037
    self.fireWith @ jquery.js?v=08c235d357750c657ac1db7d1cf656a9:1148
    jQuery.extend.ready @ jquery.js?v=08c235d357750c657ac1db7d1cf656a9:433
    completed @ jquery.js?v=08c235d357750c657ac1db7d1cf656a9:103
Dashboards.Main.js?v=8e89e10f9ca55858977d99c20148f7a6:85
    TypeError: Cannot read property 'length' of undefined
    at BaseComponent.extend.update (ionRangeSliderComponent.js?v=47871653d5a1943b738b951940888bc8:48)
    at Object.<anonymous> (Dashboards.Main.js?v=8e89e10f9ca55858977d99c20148f7a6:378)
```
